### PR TITLE
docs: Document cache-status endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To deploy the Unsplash Workers API, click the button below:
     - `fit`: (optional) Fit parameter for the image.
     - `dpr`: (optional) Device pixel ratio.
 
+- **GET /cache-status**: View the current status of the caching system.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
- [docs] Add details for **GET /cache-status** endpoint in README.md (lines ~32-40)